### PR TITLE
Update Streamio.Service runtime to 46

### DIFF
--- a/com.stremio.Service.json
+++ b/com.stremio.Service.json
@@ -1,7 +1,7 @@
 {
     "app-id": "com.stremio.Service",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "44",
+    "runtime-version": "46",
     "sdk": "org.gnome.Sdk",
     "sdk-extensions": ["org.freedesktop.Sdk.Extension.rust-stable"],
     "command": "stremio-service",

--- a/com.stremio.Service.json
+++ b/com.stremio.Service.json
@@ -44,7 +44,8 @@
             {
                 "type": "git",
                 "url": "https://github.com/Stremio/stremio-service.git",
-                "commit": "21ba2fc42de63834d115eb26d545c906db5176ef"
+                "tag": "v0.1.13",
+                "commit": "512f93126933f96c38e3f99dd263b6566004a3a9"
             },
             "./cargo-sources.json",
             "./server-source.json"


### PR DESCRIPTION
- Update com.stremio.Service runtime to 46 since runtime version 44 has reached end-of-life.
- Update com.stremio.Service to v0.1.13.